### PR TITLE
fix: Pass in server address when creating SMTP connection

### DIFF
--- a/ckanext/subscribe/mailer.py
+++ b/ckanext/subscribe/mailer.py
@@ -63,7 +63,6 @@ def _mail_recipient(
 
 def _mail_payload(msg, mail_from, recipient_email):
     # Send the email using Python's smtplib.
-    smtp_connection = smtplib.SMTP()
     if "smtp.test_server" in config:
         # If 'smtp.test_server' is configured we assume we're running tests,
         # and don't use the smtp.server, starttls, user, password etc. options.
@@ -76,6 +75,8 @@ def _mail_payload(msg, mail_from, recipient_email):
         smtp_starttls = asbool(config.get("smtp.starttls"))
         smtp_user = config.get("smtp.user")
         smtp_password = config.get("smtp.password")
+
+    smtp_connection = smtplib.SMTP(smtp_server)
 
     try:
         smtp_connection.connect(smtp_server)


### PR DESCRIPTION
This is a workaround for a bug in SMTP with Python 3.7+: https://github.com/python/cpython/issues/80275.