### PR TITLE
fix: Create Flask request context in CLI send_any_notifications command

### DIFF
--- a/ckanext/subscribe/cli.py
+++ b/ckanext/subscribe/cli.py
@@ -20,16 +20,20 @@ def subscribe():
     default=False,
     help="Repeat every 10s",
 )
-def send_any_notifications(repeatedly):
+@click.pass_context
+def send_any_notifications(ctx, repeatedly):
     """Check for activity and for any subscribers, send emails with the notifications."""
-    while True:
-        p.toolkit.get_action("subscribe_send_any_notifications")(
-            {"model": model, "ignore_auth": True}, {}
-        )
-        if not repeatedly:
-            break
-        click.echo("Repeating in 10s")
-        time.sleep(10)
+    flask_app = ctx.meta["flask_app"]
+
+    with flask_app.test_request_context():
+        while True:
+            p.toolkit.get_action("subscribe_send_any_notifications")(
+                {"model": model, "ignore_auth": True}, {}
+            )
+            if not repeatedly:
+                break
+            click.echo("Repeating in 10s")
+            time.sleep(10)
 
 
 @subscribe.command("create-test-activity")


### PR DESCRIPTION
Copied from ckanext-harvest's CLI commands that ultimately send emails.

We use ckan.lib.base.render to render email contents as HTML, and this function requires a request context. All other kinds of emails we send are prompted by a request (e.g. clicking on a subscribe or management link) so the request context exists, but when we prompt email sending with a CLI command, we need to create this context beforehand.

It looks a bit odd to use the 'test_request_context' method here, but Flask prefers that 'request_context' is only used when an actual request is handled and external code uses 'test_request_app'.